### PR TITLE
LPS-37928 Use the right portletId when hiding the default error message.

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/article/portlet/ArticlePortlet.java
+++ b/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/article/portlet/ArticlePortlet.java
@@ -30,7 +30,6 @@ import com.liferay.knowledgebase.util.ActionKeys;
 import com.liferay.knowledgebase.util.PortletKeys;
 import com.liferay.knowledgebase.util.WebKeys;
 import com.liferay.portal.NoSuchSubscriptionException;
-import com.liferay.portal.kernel.portlet.LiferayPortletConfig;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -195,12 +194,9 @@ public class ArticlePortlet extends MVCPortlet {
 
 				SessionErrors.add(renderRequest, e.getClass());
 
-				LiferayPortletConfig liferayPortletConfig =
-					(LiferayPortletConfig)getPortletConfig();
-
 				SessionMessages.add(
 					renderRequest,
-					liferayPortletConfig.getPortletId() +
+					PortalUtil.getPortletId(renderRequest) +
 						SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE);
 			}
 			else {


### PR DESCRIPTION
The portletId in the portletConfig object obtained through getPortletConfig() is the rootPortletId, but portlet_messages.jspf uses the portletId. Thus, for instantiable portlets the portletId should be obtained through portalUtil.getPortletId(request). This works in configuration views, because there the portletId of the configurationPortlet (86, non-instantiable) is used. In struts portlets, the portletConfig is properly obtained in the execute method of the super class.
