### PR TITLE
[TECHNICAL-SUPPORT | July 18] LPS-48296 Web Form portlet shows field Validation options even with validation.script.enabled=false

### DIFF
--- a/portlets/web-form-portlet/docroot/configuration.jsp
+++ b/portlets/web-form-portlet/docroot/configuration.jsp
@@ -242,17 +242,19 @@ if (!fieldsEditingDisabled) {
 			}
 		};
 
-		var toggleValidationOptions = function(event) {
-			this.next().toggle();
-		};
-
 		var webFields = A.one('.webFields');
 
 		webFields.all('select').each(toggleOptions);
 
 		webFields.delegate(['change', 'click', 'keydown'], toggleOptions, 'select');
 
-		webFields.delegate('click', toggleValidationOptions, '.validation-link');
+		<c:if test="<%= PortletPropsValues.VALIDATION_SCRIPT_ENABLED %>">
+			var toggleValidationOptions = function(event) {
+				this.next().toggle();
+			};
+
+			webFields.delegate('click', toggleValidationOptions, '.validation-link');
+		</c:if>
 
 		webFields.delegate(
 			'change',

--- a/portlets/web-form-portlet/docroot/edit_field.jsp
+++ b/portlets/web-form-portlet/docroot/edit_field.jsp
@@ -119,7 +119,7 @@ boolean ignoreRequestValue = (index != formFieldsIndex);
 		</c:when>
 	</c:choose>
 
-	<c:if test="<%= true %>">
+	<c:if test="<%= PortletPropsValues.VALIDATION_SCRIPT_ENABLED %>">
 		<c:choose>
 			<c:when test="<%= !fieldsEditingDisabled %>">
 				<div class="validation">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-48296

Hey Marcellus,

Property "validation.script.enabled" is already checked in the backend (WebFormPortlet#validate), so it doesn't make sense to display the "Validation" fields in the configuration view when the value is set to false.

Regarding the 1st commit (lipusz@ba2f9f4): the field editing is disabled (previous form data exist) we display the current fields as a non-editable elements, so I do no see any reasons for adding the script to the response in this case.

Let me know if you have any concerns,
Tibor
